### PR TITLE
Fixing reference tags to reference figure instead of image.

### DIFF
--- a/ptx/sec_deriv_implicit.ptx
+++ b/ptx/sec_deriv_implicit.ptx
@@ -549,7 +549,7 @@
             </shortdescription>
             <description>
               <p>
-                The graph in <xref ref="fig_implicit6">Figure</xref>, with tagent lines drawn at <m>(0,-1)</m>, <m>(0,0)</m>, and <m>(0,1)</m>.
+                The graph in <xref ref="fig_implicit5">Figure</xref>, with tagent lines drawn at <m>(0,-1)</m>, <m>(0,0)</m>, and <m>(0,1)</m>.
                 The tangent line at <m>(0,-1)</m> has a positive slope less than 1.
                 The tangent line at <m>(0,0)</m> has a negative slope, close to -1.
                 The tangent line at <m>(0,1)</m> has a positive slope, less than 1.
@@ -820,7 +820,7 @@
             </shortdescription>
             <description>
               <p>
-                The curve sketched in <xref ref="img_implicit9">Figure</xref> with a tangent line at <m>(8,8)</m>.
+                The curve sketched in <xref ref="fig_implicit9">Figure</xref> with a tangent line at <m>(8,8)</m>.
                 It has a slope of -1.
               </p>
             </description>
@@ -1030,8 +1030,8 @@
             </shortdescription>
             <description>
               <p>
-                The graph shown in <xref ref="fig_implicit10">Figure</xref>, with a tangent line at
-                <m>(1.5,1.5^{1.5}</m>. It has a slope of around 2.6.
+                The graph shown in <xref ref="fig_logdiffa">Figure</xref>, with a tangent line at
+                <m>(1.5,1.5^{1.5})</m>. It has a slope of around 2.6.
               </p>
             </description>
             <latex-image>


### PR DESCRIPTION
A few reference tags were accidentally referencing the image instead of the figure, which would cause errors. Additionally, I fixed a few reference tags which referred to themselves, which wouldn't be very useful.